### PR TITLE
Adding Makefile and fixing .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,1 @@
-/src/*
-!/src/build/
-!/src/include/
-!/src/CMakeLists.txt
-!/src/**/.cpp
-!/src/**/.h
-!/src/gui/
-!/src/googletest
+/src/build/*

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,42 @@
+BUILD_DIR=./build
+BIN_DIR=$(BUILD_DIR)/bin
+
+PROJECT_PATH=$(BIN_DIR)/Kalkulacka
+TEST_PATH=$(BIN_DIR)/test_lib
+PROFILE_PATH=$(BIN_DIR)/profiling
+
+LOGIN=xdohun00
+TARGET=$(PROFILE_PATH) $(PROJECT_PATH) $(TEST_PATH)
+
+####################################################
+
+.PHONY: all run profile test doc pack clean
+
+all: $(TARGET)
+
+run: $(PROJECT_PATH)
+	cd $(BIN_DIR) && ./Kalkulacka
+
+profile: $(PROFILE_PATH)
+	cd $(BIN_DIR) && ./profiling
+
+test: $(TEST_PATH)
+	cd $(BIN_DIR) && ./test_lib
+
+doc: Doxyfile
+	doxygen
+
+pack:
+	make clean
+	zip -r ../$(LOGIN) ../*
+
+clean:
+	rm -fr $(BUILD_DIR)/*
+
+##################################################
+
+$(TARGET): $(BUILD_DIR)/Makefile ./gui/* *.cpp ./include/*.h
+	make -C$(BUILD_DIR) -j8
+
+$(BUILD_DIR)/Makefile: CMakeLists.txt
+	cmake . -B$(BUILD_DIR)


### PR DESCRIPTION
Přidání `./src/Makefile` pro lehčí sestavování programu ve složce `./src`. 
Make nyní zvládá příkazy: 
- all - Zkompiluje testy, aplikaci a profiling
- run - Zkompiluje a spustí aplikaci
- doc - Vygeneruje dokument pomocí `./src/Doxyfile`
- profile - Zkompiluje a spusti profiling; čte ze `STDIN`
- test - Zkompiluje a spustí testy
- pack - Zabalí repozitář do .zip
- clean - Vyčistí obsah složky `./src/build`

Úprava souboru `.gitignore`, který nyní ignoruje jen obsah složky `./src/build/`